### PR TITLE
Some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## What's new in THIS FORK
+1. No max height of scrollbar. Show it like any other scrollbars: max height is window height.
+2. Correct work of multiple scrollbars in multiple windows. Dont overlap other popups.
+3. Render it at right column of window, not at VertSplit
+4. Make it enabled by default.
+
+API Changes:  
+obsoleted `g:popup_scrollbar_auto`  
+obsoleted `g:popup_scrollbar_max_size`
+
 [![Build Status](https://circleci.com/gh/AndrewRadev/popup_scrollbar.vim/tree/main.svg?style=shield)](https://circleci.com/gh/AndrewRadev/popup_scrollbar.vim?branch=main)
 
 This is a loose port of <https://github.com/Xuyuanp/scrollbar.nvim> for upstream Vim with popup windows instead of floating windows. Many thanks to [@Xuyuanp](https://github.com/Xuyuanp) for the scrollbar positioning logic. If you're interested in a Neovim version of this plugin, you should just use the original one.

--- a/README.md
+++ b/README.md
@@ -16,18 +16,11 @@ These three commands will enable, disable, and toggle the scrollbar:
 
 The first one installs autocommands that automatically show the scrollbar when switching to a window and update its size and position. Disabling removes these autocommands and toggling switches between the two.
 
-If you'd rather just have it enabled automatically, put the following in your vimrc:
-
-``` vim
-let g:popup_scrollbar_auto = 1
-```
-
 ## Customizing
 
 If you'd like to customize the size, shape, or color of the scrollbar, check the built-in help docs (`:help popup_scrollbar-settings`) for details. Here's a short summary of the default settings:
 
 ``` vim
-let g:popup_scrollbar_max_size = 10
 let g:popup_scrollbar_min_size = 3
 let g:popup_scrollbar_shape = {
     \ 'head': '▲',

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -39,6 +39,7 @@ function! UpdatePopup(winid) abort
         \ maxwidth: 1,
         \ maxheight: len(content),
         \ highlight: g:popup_scrollbar_highlight,
+        \ zindex: 1,
         \ })
 endfunction 
 

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -27,7 +27,7 @@ function! UpdatePopup(winid) abort
   let content += [get(g:popup_scrollbar_shape, 'tail', '▼')]
 
   let [win_row, win_col] = win_screenpos(a:winid)
-  let col = win_col + winwidth(a:winid)
+  let col = win_col + winwidth(a:winid) - 1
   let ratio = str2float(total_lines - window_height)
   let line = max([ win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio))), 1 ])
 

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -16,7 +16,7 @@ function popup_scrollbar#Show() abort
 
   let [win_row, win_col] = win_screenpos(0)
   let col = win_col + winwidth(0)
-  let ratio = (total_lines - window_height) * 1.0
+  let ratio = str2float(total_lines - window_height)
   let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
 
   if exists('w:scrollbar_popup') && w:scrollbar_popup > 0

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -1,9 +1,19 @@
+function! Hide_current_popup()
+  if exists('w:scrollbar_popup')
+    call popup_close(w:scrollbar_popup)
+  endif
+endfunction
+
 function popup_scrollbar#Show() abort
+  if (bufname() =~ 'fugitive')
+      return 
+  endif
   let total_lines   = line('$')
   let window_height = winheight(0)
   let bar_size = max([float2nr(window_height * window_height / total_lines), g:popup_scrollbar_min_size]) 
 
   if bar_size >= window_height
+      call Hide_current_popup()
     return
   endif
 
@@ -19,9 +29,7 @@ function popup_scrollbar#Show() abort
   let ratio = str2float(total_lines - window_height)
   let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
 
-  if exists('w:scrollbar_popup')
-    call popup_close(w:scrollbar_popup)
-  endif
+  call Hide_current_popup()
 
   let w:scrollbar_popup = popup_create(content, #{
         \ line: line,

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -29,7 +29,7 @@ function! UpdatePopup(winid) abort
   let [win_row, win_col] = win_screenpos(a:winid)
   let col = win_col + winwidth(a:winid)
   let ratio = str2float(total_lines - window_height)
-  let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
+  let line = max([ win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio))), 1 ])
 
   call Hide_current_popup(a:winid)
 

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -1,5 +1,4 @@
 function popup_scrollbar#Show() abort
-    " echom 'popup_scrollbar#Show '
   let total_lines   = line('$')
   let window_height = winheight(0)
   let bar_size = max([float2nr(window_height * window_height / total_lines), g:popup_scrollbar_min_size]) 
@@ -9,7 +8,6 @@ function popup_scrollbar#Show() abort
   endif
 
   let current_line = line('w$') - window_height
-  " echom 'current_line = ' . current_line
 
   let content = [get(g:popup_scrollbar_shape, 'head', '▲')]
   let body = get(g:popup_scrollbar_shape, 'body', '█')
@@ -22,7 +20,6 @@ function popup_scrollbar#Show() abort
   let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
 
   if exists('w:scrollbar_popup') && w:scrollbar_popup > 0
-      " echom 'popup_close ' . w:scrollbar_popup
     call popup_close(w:scrollbar_popup)
   endif
 
@@ -33,15 +30,10 @@ function popup_scrollbar#Show() abort
         \ maxheight: len(content),
         \ highlight: g:popup_scrollbar_highlight,
         \ })
-  " echom 'w:scrollbar_popup = ' . w:scrollbar_popup . ' win_h=' . window_height . ' total_lines=' . total_lines
 endfunction
 
 function! popup_scrollbar#Hide() abort
   if exists('w:scrollbar_popup')
-    " echom 'popup_scrollbar#Hidea ' . w:scrollbar_popup
-  else
-    " echom 'popup_scrollbar#Hidea no w:scrollbar_popup'
-  endif
   if exists('w:scrollbar_popup') && w:scrollbar_popup > 0
     call popup_close(w:scrollbar_popup)
     let w:scrollbar_popup = -1

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -1,14 +1,15 @@
 function popup_scrollbar#Show() abort
+    " echom 'popup_scrollbar#Show '
   let total_lines   = line('$')
   let window_height = winheight(0)
-  if total_lines <= window_height
+  let bar_size = max([float2nr(window_height * window_height / total_lines), g:popup_scrollbar_min_size]) 
+
+  if bar_size >= window_height
     return
   endif
 
-  let ratio = (total_lines - window_height) * 1.0
   let current_line = line('w$') - window_height
-  let bar_size = float2nr(ceil(window_height * window_height / ratio))
-  let bar_size = s:ClampSize(bar_size)
+  " echom 'current_line = ' . current_line
 
   let content = [get(g:popup_scrollbar_shape, 'head', '▲')]
   let body = get(g:popup_scrollbar_shape, 'body', '█')
@@ -17,34 +18,32 @@ function popup_scrollbar#Show() abort
 
   let [win_row, win_col] = win_screenpos(0)
   let col = win_col + winwidth(0)
-  let line = 1 + win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
+  let ratio = (total_lines - window_height) * 1.0
+  let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
 
-  if exists('b:scrollbar_popup') && b:scrollbar_popup > 0
-    call popup_close(b:scrollbar_popup)
+  if exists('w:scrollbar_popup') && w:scrollbar_popup > 0
+      " echom 'popup_close ' . w:scrollbar_popup
+    call popup_close(w:scrollbar_popup)
   endif
 
-  let b:scrollbar_popup = popup_create(content, #{
+  let w:scrollbar_popup = popup_create(content, #{
         \ line: line,
         \ col: col,
         \ maxwidth: 1,
         \ maxheight: len(content),
         \ highlight: g:popup_scrollbar_highlight,
         \ })
+  " echom 'w:scrollbar_popup = ' . w:scrollbar_popup . ' win_h=' . window_height . ' total_lines=' . total_lines
 endfunction
 
 function! popup_scrollbar#Hide() abort
-  if exists('b:scrollbar_popup') && b:scrollbar_popup > 0
-    call popup_close(b:scrollbar_popup)
-    let b:scrollbar_popup = -1
-  endif
-endfunction
-
-function s:ClampSize(size) abort
-  if a:size < g:popup_scrollbar_min_size
-    return g:popup_scrollbar_min_size
-  elseif a:size > g:popup_scrollbar_max_size
-    return g:popup_scrollbar_max_size
+  if exists('w:scrollbar_popup')
+    " echom 'popup_scrollbar#Hidea ' . w:scrollbar_popup
   else
-    return a:size
+    " echom 'popup_scrollbar#Hidea no w:scrollbar_popup'
+  endif
+  if exists('w:scrollbar_popup') && w:scrollbar_popup > 0
+    call popup_close(w:scrollbar_popup)
+    let w:scrollbar_popup = -1
   endif
 endfunction

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -5,15 +5,15 @@ function! Hide_current_popup()
 endfunction
 
 function popup_scrollbar#Show() abort
+  call Hide_current_popup()
   if (bufname() =~ 'fugitive')
-      return 
+    return 
   endif
   let total_lines   = line('$')
   let window_height = winheight(0)
   let bar_size = max([float2nr(window_height * window_height / total_lines), g:popup_scrollbar_min_size]) 
 
   if bar_size >= window_height
-      call Hide_current_popup()
     return
   endif
 
@@ -41,8 +41,8 @@ function popup_scrollbar#Show() abort
 endfunction
 
 function! popup_scrollbar#Hide() abort
+  call Hide_current_popup()
   if exists('w:scrollbar_popup')
-    call popup_close(w:scrollbar_popup)
     unlet w:scrollbar_popup
   endif
 endfunction

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -19,7 +19,7 @@ function popup_scrollbar#Show() abort
   let ratio = str2float(total_lines - window_height)
   let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
 
-  if exists('w:scrollbar_popup') && w:scrollbar_popup > 0
+  if exists('w:scrollbar_popup')
     call popup_close(w:scrollbar_popup)
   endif
 
@@ -34,8 +34,7 @@ endfunction
 
 function! popup_scrollbar#Hide() abort
   if exists('w:scrollbar_popup')
-  if exists('w:scrollbar_popup') && w:scrollbar_popup > 0
     call popup_close(w:scrollbar_popup)
-    let w:scrollbar_popup = -1
+    unlet w:scrollbar_popup
   endif
 endfunction

--- a/autoload/popup_scrollbar.vim
+++ b/autoload/popup_scrollbar.vim
@@ -1,48 +1,58 @@
-function! Hide_current_popup()
-  if exists('w:scrollbar_popup')
-    call popup_close(w:scrollbar_popup)
+let s:visiblePopups = {}
+
+function! Hide_current_popup(winid)
+  if has_key(s:visiblePopups, a:winid)
+    call popup_close(s:visiblePopups[a:winid])
   endif
 endfunction
 
-function popup_scrollbar#Show() abort
-  call Hide_current_popup()
+function! UpdatePopup(winid) abort
+  call Hide_current_popup(a:winid)
   if (bufname() =~ 'fugitive')
     return 
   endif
-  let total_lines   = line('$')
-  let window_height = winheight(0)
+  let total_lines   = line('$', a:winid)
+  let window_height = winheight(a:winid)
   let bar_size = max([float2nr(window_height * window_height / total_lines), g:popup_scrollbar_min_size]) 
 
   if bar_size >= window_height
     return
   endif
 
-  let current_line = line('w$') - window_height
+  let current_line = line('w$', a:winid) - window_height
 
   let content = [get(g:popup_scrollbar_shape, 'head', '▲')]
   let body = get(g:popup_scrollbar_shape, 'body', '█')
   let content += split(repeat(body, bar_size - 2), '\zs')
   let content += [get(g:popup_scrollbar_shape, 'tail', '▼')]
 
-  let [win_row, win_col] = win_screenpos(0)
-  let col = win_col + winwidth(0)
+  let [win_row, win_col] = win_screenpos(a:winid)
+  let col = win_col + winwidth(a:winid)
   let ratio = str2float(total_lines - window_height)
   let line = win_row + float2nr(floor((window_height - bar_size) * (current_line / ratio)))
 
-  call Hide_current_popup()
+  call Hide_current_popup(a:winid)
 
-  let w:scrollbar_popup = popup_create(content, #{
+  let s:visiblePopups[a:winid] = popup_create(content, #{
         \ line: line,
         \ col: col,
         \ maxwidth: 1,
         \ maxheight: len(content),
         \ highlight: g:popup_scrollbar_highlight,
         \ })
+endfunction 
+
+function! popup_scrollbar#Show() abort
+    for winid in s:visiblePopups->keys()
+        call UpdatePopup(winid)
+    endfor
+    call UpdatePopup(win_getid())
 endfunction
 
 function! popup_scrollbar#Hide() abort
-  call Hide_current_popup()
-  if exists('w:scrollbar_popup')
-    unlet w:scrollbar_popup
+  let winid = win_getid()
+  call Hide_current_popup(winid)
+  if has_key(s:visiblePopups, winid)
+    call remove(s:visiblePopups, winid)
   endif
 endfunction

--- a/doc/popup_scrollbar.txt
+++ b/doc/popup_scrollbar.txt
@@ -57,34 +57,14 @@ The first one installs autocommands that automatically show the scrollbar when
 switching to a window and update its size and position. Disabling removes
 these autocommands and toggling switches between the two.
 
-If you'd rather just have it enabled automatically, put the following in your
-vimrc:
->
-    let g:popup_scrollbar_auto = 1
-<
-
-
 ==============================================================================
 SETTINGS                                              *popup_scrollbar-settings*
 
-                                                        *g:popup_scrollbar_auto*
->
-    let g:popup_scrollbar_auto = 1
-<
-Default value: 0
-
-If you set this to 1, the plugin will automatically enable scrollbars when
-loaded. You can still disable them with |:PopupScrollbarDisable| and
-|:PopupScrollbarToggle|, of course.
-
-
-                                                    *g:popup_scrollbar_max_size*
                                                     *g:popup_scrollbar_min_size*
 >
-    let g:popup_scrollbar_max_size = 5
     let g:popup_scrollbar_min_size = 2
 <
-Default value: 10 and 3
+Default value: 3
 
 Set the maximum and minimum size for the scrollbar, in lines. The minimum of
 "3" shows the body once, with a head and a tail. You could still set it to 2

--- a/plugin/popup_scrollbar.vim
+++ b/plugin/popup_scrollbar.vim
@@ -6,14 +6,6 @@ let g:loaded_popup_scrollbar = '0.0.1' " version number
 let s:keepcpo = &cpo
 set cpo&vim
 
-if !exists('g:popup_scrollbar_auto')
-  let g:popup_scrollbar_auto = 0
-endif
-
-if !exists('g:popup_scrollbar_max_size')
-  let g:popup_scrollbar_max_size = 10
-endif
-
 if !exists('g:popup_scrollbar_min_size')
   let g:popup_scrollbar_min_size = 3
 endif
@@ -39,20 +31,24 @@ command! PopupScrollbarDisable call s:Disable()
 command! PopupScrollbarToggle  call s:Toggle()
 
 function s:Enable() abort
+    " echom 's:Enable()'
   let s:enabled = 1
 
   augroup PopupScrollbar
     autocmd!
-    autocmd WinScrolled,VimResized,QuitPre,WinEnter,FocusGained *
+    autocmd WinScrolled,WinResized,VimResized,QuitPre,WinEnter,FocusGained *
           \ call popup_scrollbar#Show()
-    autocmd WinLeave,BufLeave,BufWinLeave,FocusLost *
+    autocmd BufLeave,BufWinLeave,BufHidden,BufDelete *
           \ call popup_scrollbar#Hide()
+    autocmd BufEnter,BufWinEnter,BufNew,BufAdd,BufCreate *
+          \ call popup_scrollbar#Show()
   augroup END
 
   call popup_scrollbar#Show()
 endfunction
 
 function s:Disable() abort
+    " echom 's:Disable()'
   let s:enabled = 0
 
   augroup PopupScrollbar
@@ -63,6 +59,7 @@ function s:Disable() abort
 endfunction
 
 function! s:Toggle() abort
+    " echom 's:Toggle(), current=' . s:enabled 
   if s:enabled
     call s:Disable()
   else
@@ -70,9 +67,7 @@ function! s:Toggle() abort
   endif
 endfunction
 
-if g:popup_scrollbar_auto
-  call s:Enable()
-endif
+call s:Enable()
 
 let &cpo = s:keepcpo
 unlet s:keepcpo

--- a/plugin/popup_scrollbar.vim
+++ b/plugin/popup_scrollbar.vim
@@ -35,9 +35,9 @@ function s:Enable() abort
 
   augroup PopupScrollbar
     autocmd!
-    autocmd WinScrolled,WinResized,VimResized,QuitPre,WinEnter,FocusGained *
+    autocmd WinScrolled,WinResized,VimResized,QuitPre,WinEnter,FocusGained,TextChanged,CursorMoved *
           \ call popup_scrollbar#Show()
-    autocmd BufLeave,BufWinLeave,BufHidden,BufDelete *
+    autocmd BufHidden,BufDelete,WinClosed *
           \ call popup_scrollbar#Hide()
     autocmd BufEnter,BufWinEnter,BufNew,BufAdd,BufCreate *
           \ call popup_scrollbar#Show()

--- a/plugin/popup_scrollbar.vim
+++ b/plugin/popup_scrollbar.vim
@@ -31,7 +31,6 @@ command! PopupScrollbarDisable call s:Disable()
 command! PopupScrollbarToggle  call s:Toggle()
 
 function s:Enable() abort
-    " echom 's:Enable()'
   let s:enabled = 1
 
   augroup PopupScrollbar
@@ -48,7 +47,6 @@ function s:Enable() abort
 endfunction
 
 function s:Disable() abort
-    " echom 's:Disable()'
   let s:enabled = 0
 
   augroup PopupScrollbar
@@ -59,7 +57,6 @@ function s:Disable() abort
 endfunction
 
 function! s:Toggle() abort
-    " echom 's:Toggle(), current=' . s:enabled 
   if s:enabled
     call s:Disable()
   else

--- a/plugin/popup_scrollbar.vim
+++ b/plugin/popup_scrollbar.vim
@@ -35,11 +35,11 @@ function s:Enable() abort
 
   augroup PopupScrollbar
     autocmd!
-    autocmd WinScrolled,WinResized,VimResized,QuitPre,WinEnter,FocusGained,TextChanged,CursorMoved *
-          \ call popup_scrollbar#Show()
+    autocmd WinScrolled,WinResized,VimResized,WinEnter,TextChanged,CursorMoved *
+         \ call popup_scrollbar#Show()
     autocmd BufHidden,BufDelete,WinClosed *
           \ call popup_scrollbar#Hide()
-    autocmd BufEnter,BufWinEnter,BufNew,BufAdd,BufCreate *
+    autocmd BufEnter,BufNew,BufAdd,BufCreate *
           \ call popup_scrollbar#Show()
   augroup END
 


### PR DESCRIPTION
if you don't mind refreshing an old plugin:

## What's new in THIS FORK
1. No max height of scrollbar. Show it like any other scrollbars: max height is window height.
2. Correct work of multiple scrollbars in multiple windows. Dont overlap other popups.
3. Render it at right column of window, not at VertSplit
4. Make it enabled by default.

API Changes:  
obsoleted `g:popup_scrollbar_auto`  
obsoleted `g:popup_scrollbar_max_size`